### PR TITLE
fix: 修复stylelintignore文件规则有空格失效的问题

### DIFF
--- a/packages/f2elint/src/config/_markdownlintignore.ejs
+++ b/packages/f2elint/src/config/_markdownlintignore.ejs
@@ -1,5 +1,5 @@
 <%_ if (enableMarkdownlint) {  _%>
 <%_ markdownLintIgnores.forEach((txt) => { _%>
-  <%= txt %>
+<%= txt %>
 <% }) %>
 <%_ } _%>

--- a/packages/f2elint/src/config/_stylelintignore.ejs
+++ b/packages/f2elint/src/config/_stylelintignore.ejs
@@ -1,5 +1,5 @@
 <%_ if (enableStylelint) {  _%>
 <%_ stylelintIgnores.forEach((txt) => { _%>
-  <%= txt %>
+<%= txt %>
 <% }) %>
 <%_ } _%>


### PR DESCRIPTION
修复stylelintignore文件规则有空格失效的问题
也修改 markdownlintignore空格