### PR TITLE
feat add config createDefaultProgram

### DIFF
--- a/packages/eslint-config-ali/CHANGELOG.md
+++ b/packages/eslint-config-ali/CHANGELOG.md
@@ -1,5 +1,23 @@
 # 更新日志
 
+## 12.2.1 (2021-08-11)
+
+### 变更
+
+- TS 规范 parserOptions 加回 createDefaultProgram 配置，兼容所有 tsconfig 配置。已知多包仓库 ESLint 检测速度会变慢。若检测速度非常慢，可考虑增量扫描或者添加下面配置加速：
+
+```js
+{
+  parserOptions: {
+    project: [],
+    createDefaultProgram: false,
+  },
+  rules: {
+    '@typescript-eslint/dot-notation': 'off'
+  }
+}
+```
+
 ## 12.2.0 (2021-08-05)
 
 ### 变更

--- a/packages/eslint-config-ali/CHANGELOG.md
+++ b/packages/eslint-config-ali/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 变更
 
-- TS 规范 parserOptions 加回 createDefaultProgram 配置，兼容所有 tsconfig 配置。已知多包仓库 ESLint 检测速度会变慢。若检测速度非常慢，可考虑增量扫描或者添加下面配置加速：
+- TS 规范 parserOptions 加回 createDefaultProgram 配置，兼容所有 tsconfig 配置。已知多包仓库 ESLint 检测速度会变慢。若检测速度非常慢，可考虑增量扫描或者使用下面配置加速：
 
 ```js
 {

--- a/packages/eslint-config-ali/package.json
+++ b/packages/eslint-config-ali/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-ali",
-  "version": "12.2.0",
+  "version": "12.2.1",
   "description": "ESLint Shareable Config for Alibaba F2E Guidelines",
   "main": "index.js",
   "keywords": [

--- a/packages/eslint-config-ali/rules/typescript.js
+++ b/packages/eslint-config-ali/rules/typescript.js
@@ -22,9 +22,10 @@ module.exports = {
   },
   parserOptions: {
     project: './tsconfig.json', // default project config
+    createDefaultProgram: true, // 兼容未在 tsconfig.json 中 provided 的文件
     extraFileExtensions: ['.vue'],
   },
-  rules: {
+  rules: {  
     /**
      * 【强制】将重载的函数写在一起以增加代码可读性
      * @link https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/adjacent-overload-signatures.md

--- a/packages/eslint-config-ali/rules/typescript.js
+++ b/packages/eslint-config-ali/rules/typescript.js
@@ -25,7 +25,7 @@ module.exports = {
     createDefaultProgram: true, // 兼容未在 tsconfig.json 中 provided 的文件
     extraFileExtensions: ['.vue'],
   },
-  rules: {  
+  rules: {
     /**
      * 【强制】将重载的函数写在一起以增加代码可读性
      * @link https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/adjacent-overload-signatures.md


### PR DESCRIPTION
考虑到 eslibt-config-ali 是基础包，并且 createDefaultProgram 配置已存在较多版本，加回此配置，避免影响其他项目。

多包仓库扫描慢问题，由上层仓库覆盖配置修复。