### PR TITLE
支持 ESLint 8.x

### DIFF
--- a/packages/eslint-config-ali/CHANGELOG.md
+++ b/packages/eslint-config-ali/CHANGELOG.md
@@ -1,5 +1,8 @@
 # 更新日志
 
+## 12.3.0 (2021-10-13)
+- 更新 `@typescript-eslint/eslint-plugin` 及 `@typescript-eslint/parser` 版本（[说明](https://github.com/typescript-eslint/typescript-eslint/issues/3738)），支持 ESLint 8.x
+
 ## 12.2.2 (2021-09-14)
 
 ### 删除

--- a/packages/eslint-config-ali/package.json
+++ b/packages/eslint-config-ali/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-ali",
-  "version": "12.2.2",
+  "version": "12.3.0",
   "description": "ESLint Shareable Config for Alibaba F2E Guidelines",
   "main": "index.js",
   "keywords": [
@@ -45,8 +45,8 @@
     "eslint": ">=6.8.0"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^4.10.0",
-    "@typescript-eslint/parser": "^4.10.0",
+    "@typescript-eslint/eslint-plugin": "^5.0.0",
+    "@typescript-eslint/parser": "^5.0.0",
     "babel-eslint": "^10.1.0",
     "eslint": "^7.15.0",
     "eslint-config-egg": "^9.0.0",


### PR DESCRIPTION
 更新 `@typescript-eslint/eslint-plugin` 及 `@typescript-eslint/parser` 版本（[说明](https://github.com/typescript-eslint/typescript-eslint/issues/3738)），支持 ESLint 8.x

回归进度：
* [x] ESLint 8.x
* [x] ESLint 7.x
* [x] ESLint 6.x