### PR TITLE
feat: add build-scripts output to eslintignore

### DIFF
--- a/packages/f2elint/CHANGELOG.md
+++ b/packages/f2elint/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 更新日志
 
+## 2.1.0 (2021-12-17)
+
+- 增加 `build-scripts` 产物路径到 `.eslintignore` (`coverage/`, `es/`, `lib/`)
+
 ## 2.0.2 (2021-12-15)
 - 升级 `eslint-config-egg` 到 10.x
 

--- a/packages/f2elint/package.json
+++ b/packages/f2elint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "f2elint",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Linter for Alibaba F2E Guidelines",
   "bin": "./lib/cli.js",
   "main": "./lib/index.js",

--- a/packages/f2elint/src/config/_eslintignore.ejs
+++ b/packages/f2elint/src/config/_eslintignore.ejs
@@ -1,6 +1,9 @@
-node_modules/
 build/
+coverage/
 dist/
+es/
+lib/
+node_modules/
 **/*.min.js
 **/*-min.js
 **/*.bundle.js


### PR DESCRIPTION
build-scripts 以及类似的物料构建工具会生成 `coverage/`（如果有 --coverage 参数）, `es/`, `lib/` 文件夹，这些通常也是要避免被 eslint 检查的。