### PR TITLE
Fix with prettier

### DIFF
--- a/packages/f2elint/CHANGELOG.md
+++ b/packages/f2elint/CHANGELOG.md
@@ -1,13 +1,19 @@
 # 更新日志
 
+## 2.2.0 (2022-01-06)
+
+- 如果启用了 Prettier，运行 `f2elint-fix` 时先执行 Prettier 格式化
+
 ## 2.1.0 (2021-12-17)
 
 - 增加 `build-scripts` 产物路径到 `.eslintignore` (`coverage/`, `es/`, `lib/`)
 
 ## 2.0.2 (2021-12-15)
+
 - 升级 `eslint-config-egg` 到 10.x
 
 ## 2.0.1 (2021-12-07)
+
 - 修复 `commitlint` 硬编码路径的问题
 
 ## 2.0.0 (2021-12-01)

--- a/packages/f2elint/CHANGELOG.md
+++ b/packages/f2elint/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 2.2.0 (2022-01-06)
 
-- 如果启用了 Prettier，运行 `f2elint-fix` 时先执行 Prettier 格式化
+- 运行 `f2elint-fix` 时提前执行 Prettier 格式化，避免 Prettier 已修复的问题出现在 ESLint/Stylelint 结果中
+- 修复 Prettier 命令运行失败的问题（Command failed with ENOENT 被 catch 了没有输出）改用 Node API 模式
 
 ## 2.1.0 (2021-12-17)
 

--- a/packages/f2elint/src/utils/constants.ts
+++ b/packages/f2elint/src/utils/constants.ts
@@ -84,6 +84,9 @@ export const ESLINT_IGNORE_PATTERN: string[] = [
   'node_modules/',
   'build/',
   'dist/',
+  'coverage/',
+  'es/',
+  'lib/',
   '**/*.min.js',
   '**/*-min.js',
   '**/*.bundle.js',
@@ -101,6 +104,9 @@ export const STYLELINT_IGNORE_PATTERN: string[] = [
   'node_modules/',
   'build/',
   'dist/',
+  'coverage/',
+  'es/',
+  'lib/',
   '**/*.min.css',
   '**/*-min.css',
   '**/*.bundle.css',
@@ -114,7 +120,14 @@ export const MARKDOWN_LINT_FILE_EXT: string[] = ['.md'];
 /**
  * markdownLint 扫描忽略的文件或文件目录
  */
-export const MARKDOWN_LINT_IGNORE_PATTERN: string[] = ['node_modules/', 'build/', 'dist/'];
+export const MARKDOWN_LINT_IGNORE_PATTERN: string[] = [
+  'node_modules/',
+  'build/',
+  'dist/',
+  'coverage/',
+  'es/',
+  'lib/',
+];
 
 /**
  * Prettier 扫描文件扩展名

--- a/packages/f2elint/src/utils/constants.ts
+++ b/packages/f2elint/src/utils/constants.ts
@@ -115,3 +115,24 @@ export const MARKDOWN_LINT_FILE_EXT: string[] = ['.md'];
  * markdownLint 扫描忽略的文件或文件目录
  */
 export const MARKDOWN_LINT_IGNORE_PATTERN: string[] = ['node_modules/', 'build/', 'dist/'];
+
+/**
+ * Prettier 扫描文件扩展名
+ */
+export const PRETTIER_FILE_EXT = [
+  ...STYLELINT_FILE_EXT,
+  ...ESLINT_FILE_EXT,
+  ...MARKDOWN_LINT_FILE_EXT,
+];
+
+/**
+ * Prettier 扫描忽略的文件或文件目录
+ */
+export const PRETTIER_IGNORE_PATTERN: string[] = [
+  'node_modules/**/*',
+  'build/**/*',
+  'dist/**/*',
+  'lib/**/*',
+  'es/**/*',
+  'coverage/**/*',
+];


### PR DESCRIPTION
- 运行 `f2elint-fix` 时提前执行 Prettier 格式化，避免 Prettier 已修复的问题出现在 ESLint/Stylelint 结果中
- 修复 Prettier 命令运行失败的问题（Command failed with ENOENT 被 catch 了没有输出）改用 Node API 模式