### PR TITLE
fix: markdownlint deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
     "lint": "markdownlint -c .markdownlint.json README.md **/*.md"
   },
   "devDependencies": {
-    "markdownlint": "^0.25.1"
+    "markdownlint": "0.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "lint": "markdownlint -c .markdownlint.json README.md **/*.md"
   },
   "devDependencies": {
-    "markdownlint": "^0.22.0",
-    "markdownlint-config-ali": "^0.1.1"
+    "markdownlint": "^0.25.1"
   }
 }

--- a/packages/f2elint/package.json
+++ b/packages/f2elint/package.json
@@ -99,7 +99,7 @@
     "inquirer": "^7.3.3",
     "is-docker": "^2.1.1",
     "lodash": "^4.17.20",
-    "markdownlint": "^0.25.1",
+    "markdownlint": "0.x",
     "markdownlint-config-ali": "^0.1.1",
     "markdownlint-rule-helpers": "^0.13.0",
     "ora": "^5.1.0",

--- a/packages/markdownlint-config-ali/package.json
+++ b/packages/markdownlint-config-ali/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdownlint-config-ali",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "markdownlint shareable configuration for Alibaba F2E Guidelines",
   "main": "index.json",
   "keywords": [
@@ -23,6 +23,6 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "markdownlint": "^0.21.1"
+    "markdownlint": "^0.25.1"
   }
 }

--- a/packages/markdownlint-config-ali/package.json
+++ b/packages/markdownlint-config-ali/package.json
@@ -23,6 +23,6 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "markdownlint": "^0.25.1"
+    "markdownlint": "0.x"
   }
 }


### PR DESCRIPTION
tnpm 9 默认会检查 peerDependencies，检查不通过会失败，因此还是修复一下