### PR TITLE
fix: custom markdownlint.json does not work

### DIFF
--- a/packages/f2elint/src/cli.ts
+++ b/packages/f2elint/src/cli.ts
@@ -25,7 +25,7 @@ const installDepsIfThereNo = async () => {
   const lintConfigFiles = [].concat(
     glob.sync('.eslintrc?(.@(js|yaml|yml|json))', { cwd }),
     glob.sync('.stylelintrc?(.@(js|yaml|yml|json))', { cwd }),
-    glob.sync('.markdownlint(.@(yaml|yml|json))', { cwd }),
+    glob.sync('.markdownlint?(.@(yaml|yml|json))', { cwd }),
   );
   const nodeModulesPath = path.resolve(cwd, 'node_modules');
 

--- a/packages/f2elint/src/lints/markdownlint/getMarkdownlintConfig.ts
+++ b/packages/f2elint/src/lints/markdownlint/getMarkdownlintConfig.ts
@@ -20,7 +20,7 @@ export function getMarkdownlintConfig(opts: ScanOptions, pkg: PKG, config: Confi
     // 若用户传入了 markdownlintOptions，则用用户的
     Object.assign(lintConfig, config.markdownlintOptions);
   } else {
-    const lintConfigFiles = glob.sync('.markdownlint(.@(yaml|yml|json))', { cwd });
+    const lintConfigFiles = glob.sync('.markdownlint?(.@(yaml|yml|json))', { cwd });
     if (lintConfigFiles.length === 0) {
       lintConfig.config = markdownLintConfigAli;
     } else {


### PR DESCRIPTION
项目目录下的 markdownlint.json 配置未生效，原因是未成功匹配到配置文件
<img width="1419" alt="22" src="https://user-images.githubusercontent.com/8936924/181224906-1aeaf370-d8c1-4ca4-9fbf-6d3d1ee37d29.png">
