### PR TITLE
fix: eslint-config-ali error

### DIFF
--- a/packages/eslint-config-ali/rules/react.js
+++ b/packages/eslint-config-ali/rules/react.js
@@ -217,10 +217,10 @@ module.exports = {
     'react/jsx-wrap-multilines': [
       'error',
       {
-        declaration: true,
-        assignment: true,
-        return: true,
-        arrow: true,
+        declaration: 'parens-new-line',
+        assignment: 'parens-new-line',
+        return: 'parens-new-line',
+        arrow: 'parens-new-line',
       },
     ],
 

--- a/packages/eslint-config-ali/rules/typescript.js
+++ b/packages/eslint-config-ali/rules/typescript.js
@@ -50,10 +50,10 @@ module.exports = {
     '@typescript-eslint/ban-ts-comment': [
       'warn',
       {
-        'ts-expect-error': 'allow-with-description',
-        'ts-ignore': 'allow-with-description',
-        'ts-nocheck': 'allow-with-description',
-        'ts-check': 'allow-with-description',
+        'ts-expect-error': true,
+        'ts-ignore': true,
+        'ts-nocheck': true,
+        'ts-check': true,
       },
     ],
 


### PR DESCRIPTION
- 修复了多行的 JSX 标签需用小括号包裹且换行的配置问题，即"react/jsx-wrap-multilines"值true改为'parens-new-line'；
- 修复了"@typescript-eslint/ban-ts-comment"值"allow-with-description" 应该改为true；