### PR TITLE
fix: 修复ts存在注解的属性缩进检测不对问题

### DIFF
--- a/packages/eslint-config-ali/rules/base/style.js
+++ b/packages/eslint-config-ali/rules/base/style.js
@@ -113,6 +113,7 @@ module.exports = {
           'JSXText',
           'JSXEmptyExpression',
           'JSXSpreadChild',
+          'PropertyDefinition',
         ],
         ignoreComments: false,
       },

--- a/packages/eslint-config-ali/rules/typescript.js
+++ b/packages/eslint-config-ali/rules/typescript.js
@@ -204,6 +204,7 @@ module.exports = {
           'JSXText',
           'JSXEmptyExpression',
           'JSXSpreadChild',
+          'PropertyDefinition',
         ],
         ignoreComments: false,
       },


### PR DESCRIPTION
ts 存在注解的属性，缩进检测不正确

https://stackoverflow.com/questions/70642350/eslint-indent-rule-indents-decorated-members